### PR TITLE
Added setup.py to install gatdaem1d to python

### DIFF
--- a/python/gatdaem1d/__init__.py
+++ b/python/gatdaem1d/__init__.py
@@ -13,10 +13,10 @@ cptr = np.ctypeslib.as_ctypes;
 def load_library():
     import platform;
     if(platform.system() == "Windows"):
-        libname = os.path.dirname(os.path.realpath(__file__)) + "\gatdaem1d.dll";
+        ext = '.dll'
     else:
-        libname = os.path.dirname(os.path.realpath(__file__)) + "/gatdaem1d.so";
-    print("Loading shared library ",libname);
+        ext = '.so'
+    libname = os.path.join(os.path.dirname(os.path.realpath(__file__)),"gatdaem1d"+ext)
     lib = ctypes.CDLL(libname)
     return lib;
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# Setup Script
+# Author: Leon Foks
+# March 10 2017
+import sys
+import os
+from os.path import join
+
+# Test Python's version
+major, minor = sys.version_info[0:2]
+if (major, minor) < (3, 5):
+    sys.stderr.write('\nPython 3.5 or later is needed to use this package\n')
+    sys.exit(1)
+
+try:
+    from setuptools import setup
+except ImportError:
+    pass
+
+setup(name='gatdaem1d',
+      packages=['gatdaem1d'],
+      scripts=[],
+      version=1.0,
+      description='Time domain electromagnetic forward modeller',
+      long_description='',
+      classifiers=[
+        'Development Status :: 0 - Alpha',
+        'License :: OSI Approved :: GPL?',
+        'Programming Language :: Python :: 3.5',
+        'Topic :: Electromagnetic :: forward modelling :: geophysics',
+      ],
+      author='Ross Brodie',
+      author_email='ross.c.brodie@ga.gov.au',
+      install_requires=[
+          'numpy>=1.11',
+      ],
+      url='https://github.com/GeoscienceAustralia/ga-aem')
+#      ext_modules=[module1])


### PR DESCRIPTION
Hi Ross,

I have included a setup.py file that will allow users to install the python bindings to gatdaem1d. 
Users will still need to compile gatdaem1d themselves, but they can then simply run either
* pip install .
or
* python setup.py install
from the python directory in your repository. This will allow them to import the module e.g.
from gatdaem1d import TDAEMSystem

I have left some meta data out of the setup.py file since that should be filled in by you.  The fields to be completed are
* long_description
* classifiers
You may also wish to change the other descriptors to your liking!

Hope this helps!
Leon