### PR TITLE
Setup.py was not putting the c++ library in the python install directory

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -19,6 +19,8 @@ except ImportError:
 
 setup(name='gatdaem1d',
       packages=['gatdaem1d'],
+      package_dir={'gatdaem1d':'gatdaem1d'},
+      package_data={'gatdaem1d':['gatdaem1d.so']},
       scripts=[],
       version=1.0,
       description='Time domain electromagnetic forward modeller',
@@ -35,4 +37,3 @@ setup(name='gatdaem1d',
           'numpy>=1.11',
       ],
       url='https://github.com/GeoscienceAustralia/ga-aem')
-#      ext_modules=[module1])


### PR DESCRIPTION
Was getting the following error because the shared object was not installed correctly with the python package.

```
import gatdaem1d
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/nfoks/anaconda/lib/python3.5/site-packages/gatdaem1d/__init__.py", line 24, in <module>
    tdlib = load_library();
  File "/Users/nfoks/anaconda/lib/python3.5/site-packages/gatdaem1d/__init__.py", line 20, in load_library
    lib = ctypes.CDLL(libname)
  File "/Users/nfoks/anaconda/lib/python3.5/ctypes/__init__.py", line 347, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: dlopen(/Users/nfoks/anaconda/lib/python3.5/site-packages/gatdaem1d/gatdaem1d.so, 6): image not found
```

Added package information so the c++ library is installed correctly