### PR TITLE
Updated install for python bindings only

### DIFF
--- a/cmake_build_python_bindings.sh
+++ b/cmake_build_python_bindings.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-module load gcc/13.2.0
-module load cmake/3.21.4
-module load fftw3/3.3.8
-module list 
+#module load gcc/13.2.0
+#module load cmake/3.21.4
+#module load fftw3/3.3.8
+#module list 
 
 # Add the PETSc pkg-config path to the pkg-config search path
 export PKG_CONFIG_PATH=$PETSC_DIR/lib/pkgconfig:$PKG_CONFIG_PATH
@@ -19,6 +19,6 @@ export INSTALL_DIR=$PWD/install-gnu
 mkdir $BUILD_DIR
 cd $BUILD_DIR
 
-cmake -Wno-dev -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_COMPILER=${CXX} -DCMAKE_BUILD_TYPE=Release -DWITH_MPI=OFF -DWITH_NETCDF=OFF -DWITH_GDAL=OFF -DWITH_PETSC=OFF .. 
+cmake -Wno-dev -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_COMPILER=${CXX} -DCMAKE_BUILD_TYPE=Release -DWITH_MPI=OFF -DWITH_NETCDF=OFF -DWITH_GDAL=OFF -DWITH_PETSC=OFF -DCMAKE_PREFIX_PATH=$FFTW_ROOT .. 
 cmake --build . --target python-bindings
 cmake --install . --prefix python/gatdaem1d

--- a/cmake_build_python_bindings.sh
+++ b/cmake_build_python_bindings.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+module load gcc/13.2.0
+module load cmake/3.21.4
+module load fftw3/3.3.8
+module list 
+
+# Add the PETSc pkg-config path to the pkg-config search path
+export PKG_CONFIG_PATH=$PETSC_DIR/lib/pkgconfig:$PKG_CONFIG_PATH
+
+# pkg-config for PETSc seems non-standard on gadi so add the ompi/compiler specific library directory that contains the library file libpetsc.so
+export PETSC_LIBRARY_DIR=$PETSC_DIR/lib/ompi3/GNU
+
+# BUILD_DIR is a temporary directory for building (compiling and linking)
+export BUILD_DIR=$PWD/build-gnu
+# INSTALL_DIR is the directory for installing the build package
+export INSTALL_DIR=$PWD/install-gnu
+
+mkdir $BUILD_DIR
+cd $BUILD_DIR
+
+cmake -Wno-dev -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_COMPILER=${CXX} -DCMAKE_BUILD_TYPE=Release -DWITH_MPI=OFF -DWITH_NETCDF=OFF -DWITH_GDAL=OFF -DWITH_PETSC=OFF .. 
+cmake --build . --target python-bindings
+cmake --install . --prefix python/gatdaem1d

--- a/python/setup.py
+++ b/python/setup.py
@@ -4,6 +4,7 @@
 # March 10 2017
 # Updated: Ross C Brodie, March 20 2017
 # Updated: Ross C Brodie, March 21 2024 to Version 2.0
+# Updated: Leon Foks, June 5 2024. Added .dylib 
 import sys
 import os
 from os.path import join
@@ -22,7 +23,7 @@ except ImportError:
 setup(name='gatdaem1d',
       packages=['gatdaem1d'],
       package_dir={'gatdaem1d':'gatdaem1d'},
-      package_data={'gatdaem1d':['gatdaem1d.so', 'gatdaem1d.dll']},
+      package_data={'gatdaem1d':['gatdaem1d.so', 'gatdaem1d.dll', 'gatdaem1d.dylib']},
       scripts=[],
       version=2.0,
       description='Time-domain airborne electromagnetic forward modelling.',


### PR DESCRIPTION
Hey guys,

I've added an extra python bindings only shell script to aid in that install. I've tested this on both my Mac and our Cray.

Ive updated the setup.py file to handle .dylib which was showing up on my latest Mac build instead of .so.

Cheers!